### PR TITLE
Verlinke Material im Zeitplan

### DIFF
--- a/_includes/lc/schedule.html
+++ b/_includes/lc/schedule.html
@@ -5,7 +5,7 @@
       <tr> <td>09:30</td>  <td><a href="https://librarycarpentry.github.io/lc-data-intro/">Data Intro for Librarians</a></td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.github.io/lc-shell/">Shell Lessons for Libraries</a></td> </tr>
+      <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.github.io/lc-shell/">Shell Lessons for Libraries</a> (<a href="mailto:katrin.leinweber@tib.eu">KL</a>)</td> </tr>
       <tr> <td>14:30</td>  <td>Coffee</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>

--- a/_includes/lc/schedule.html
+++ b/_includes/lc/schedule.html
@@ -14,7 +14,7 @@
   <div class="col-md-6">
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr> <td>09:00</td>  <td>Python for Librarians</td> </tr>
+      <tr> <td>09:00</td>  <td><a href="https://github.com/foerstner-lab/Bits_and_pieces_for_the_carpentries_workshops/tree/master/python">Python for Librarians</a> (<a href="https://github.com/LibraryCarpentry/lc-python-intro">Standard</a>)</td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
       <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.org/lc-open-refine/">OpenRefine</a></td> </tr>

--- a/_includes/lc/schedule.html
+++ b/_includes/lc/schedule.html
@@ -2,10 +2,10 @@
   <div class="col-md-6">
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>09:30</td>  <td>Data Intro for Librarians</td> </tr>
+      <tr> <td>09:30</td>  <td><a href="https://librarycarpentry.github.io/lc-data-intro/">Data Intro for Librarians</a></td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Shell Lessons for Libraries</td> </tr>
+      <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.github.io/lc-shell/">Shell Lessons for Libraries</a></td> </tr>
       <tr> <td>14:30</td>  <td>Coffee</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>
@@ -17,7 +17,7 @@
       <tr> <td>09:00</td>  <td>Python for Librarians</td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>OpenRefine</td> </tr>
+      <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.org/lc-open-refine/">OpenRefine</a></td> </tr>
       <tr> <td>14:30</td>  <td>Coffee</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>


### PR DESCRIPTION
Antwort auf https://github.com/vdb-org/2019-06-26-blb-karlsruhe/pull/1#issuecomment-503475248 ;-)

IMHO sollten wir die Einträge im Zeitplan auf die Lessons verlinken. Hätte ich erst nach dem WS gemacht, aber wenn schon danach gefragt wurde, gerne auch vorher.

@Tillsa: War mir nicht sicher, ob du [lc-python](https://librarycarpentry.org/lc-python-intro/) machst oder eine Variante davon. Bitte:

- [x] füge den Link hinzu & merge dann.